### PR TITLE
Fix episode carousel preselection and centered alignment

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowsingUtils.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowsingUtils.kt
@@ -204,12 +204,10 @@ object BrowsingUtils {
 	)
 
 	@JvmStatic
-	fun createNextEpisodesRequest(seasonId: UUID, indexNumber: Int) = GetItemsRequest(
+	fun createNextEpisodesRequest(seasonId: UUID) = GetItemsRequest(
 		fields = ItemRepository.itemFields,
 		parentId = seasonId,
 		includeItemTypes = setOf(BaseItemKind.EPISODE),
-		startIndex = indexNumber,
-		limit = 20,
 	)
 
 	@JvmStatic

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsFragment.java
@@ -110,7 +110,6 @@ import kotlinx.serialization.json.Json;
 import timber.log.Timber;
 
 public class FullDetailsFragment extends Fragment implements RecordingIndicatorView, View.OnKeyListener {
-
     private int BUTTON_SIZE;
 
     DetailButton mResumeButton;
@@ -721,10 +720,17 @@ public class FullDetailsFragment extends Fragment implements RecordingIndicatorV
                 break;
 
             case EPISODE:
-                if (mBaseItem.getSeasonId() != null && mBaseItem.getIndexNumber() != null) {
-                    // query index is zero-based but episode no is not
-                    ItemRowAdapter nextAdapter = new ItemRowAdapter(requireContext(), BrowsingUtils.createNextEpisodesRequest(mBaseItem.getSeasonId(), mBaseItem.getIndexNumber()), 0, false, true, new CardPresenter(true, 120), adapter);
-                    addItemRow(adapter, nextAdapter, 5, getString(R.string.lbl_next_episode));
+                if (mBaseItem.getSeasonId() != null && mBaseItem.getId() != null) {
+                    ItemRowAdapter nextAdapter = new ItemRowAdapter(requireContext(), BrowsingUtils.createNextEpisodesRequest(mBaseItem.getSeasonId()), 0, false, true, new CardPresenter(true, 120), adapter);
+                    nextAdapter.setInitialSelectionItemId(mBaseItem.getId());
+                    if (mBaseItem.getIndexNumber() != null) {
+                        nextAdapter.setInitialSelectionIndex(Math.max(0, mBaseItem.getIndexNumber() - 1));
+                    }
+                    String episodesHeader = getString(R.string.lbl_episodes);
+                    if (mBaseItem.getParentIndexNumber() != null && mBaseItem.getParentIndexNumber() != 0) {
+                        episodesHeader = getString(R.string.lbl_season_number, mBaseItem.getParentIndexNumber()) + " " + episodesHeader;
+                    }
+                    addItemRow(adapter, nextAdapter, 5, episodesHeader);
                 }
 
                 //Guest stars

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemRowAdapter.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemRowAdapter.java
@@ -52,11 +52,16 @@ import org.koin.java.KoinJavaComponent;
 
 import java.time.Instant;
 import java.util.List;
+import java.util.UUID;
 
 import kotlin.Lazy;
 import timber.log.Timber;
 
 public class ItemRowAdapter extends MutableObjectAdapter<Object> {
+    public interface SelectionIndexListener {
+        void onSelectionIndexReady(int index);
+    }
+
     private GetItemsRequest mQuery;
     private GetNextUpRequest mNextUpQuery;
     private GetSeasonsRequest mSeasonQuery;
@@ -105,6 +110,9 @@ public class ItemRowAdapter extends MutableObjectAdapter<Object> {
     private boolean preferParentThumb = false;
     private String mGenreFilter;
     private boolean staticHeight = false;
+    private int initialSelectionIndex = -1;
+    private UUID initialSelectionItemId = null;
+    private SelectionIndexListener selectionIndexListener = null;
 
     private final Lazy<org.jellyfin.sdk.api.client.ApiClient> api = inject(org.jellyfin.sdk.api.client.ApiClient.class);
     private final Lazy<UserViewsRepository> userViewsRepository = inject(UserViewsRepository.class);
@@ -669,6 +677,40 @@ public class ItemRowAdapter extends MutableObjectAdapter<Object> {
 
             updateVisibleItemLoading();
         }
+    }
+
+    public void setInitialSelectionIndex(int initialSelectionIndex) {
+        this.initialSelectionIndex = Math.max(initialSelectionIndex, -1);
+
+        if (this.initialSelectionIndex >= 0 && selectionIndexListener != null) {
+            selectionIndexListener.onSelectionIndexReady(this.initialSelectionIndex);
+        }
+    }
+
+    public int peekInitialSelectionIndex() {
+        return initialSelectionIndex;
+    }
+
+    public void markInitialSelectionApplied() {
+        initialSelectionIndex = -1;
+    }
+
+    public int consumeInitialSelectionIndex() {
+        int selectedIndex = initialSelectionIndex;
+        initialSelectionIndex = -1;
+        return selectedIndex;
+    }
+
+    public void setInitialSelectionItemId(@Nullable UUID itemId) {
+        this.initialSelectionItemId = itemId;
+    }
+
+    public @Nullable UUID getInitialSelectionItemId() {
+        return initialSelectionItemId;
+    }
+
+    public void setSelectionIndexListener(@Nullable SelectionIndexListener listener) {
+        this.selectionIndexListener = listener;
     }
 
     private void updateVisibleItemLoading() {

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemRowAdapterHelper.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemRowAdapterHelper.kt
@@ -25,6 +25,7 @@ import org.jellyfin.sdk.api.client.extensions.tvShowsApi
 import org.jellyfin.sdk.api.client.extensions.userLibraryApi
 import org.jellyfin.sdk.api.client.extensions.userViewsApi
 import org.jellyfin.sdk.api.client.extensions.videosApi
+import org.jellyfin.sdk.model.api.BaseItemDto
 import org.jellyfin.sdk.model.api.ItemFilter
 import org.jellyfin.sdk.model.api.ItemSortBy
 import org.jellyfin.sdk.model.api.SeriesTimerInfoDto
@@ -42,6 +43,16 @@ import org.jellyfin.sdk.model.api.request.GetSimilarItemsRequest
 import org.jellyfin.sdk.model.api.request.GetUpcomingEpisodesRequest
 import timber.log.Timber
 import kotlin.math.min
+import java.util.UUID
+
+internal fun findInitialSelectionIndexByItemId(
+	items: List<BaseItemDto>,
+	selectedItemId: UUID?,
+): Int {
+	if (selectedItemId == null) return -1
+	val index = items.indexOfFirst { it.id == selectedItemId }
+	return index
+}
 
 fun <T : Any> ItemRowAdapter.setItems(
 	items: Collection<T>,
@@ -588,14 +599,25 @@ fun ItemRowAdapter.retrieveItems(
 	}
 	ProcessLifecycleOwner.get().lifecycleScope.launch {
 		runCatching {
-			val response = withContext(Dispatchers.IO) {
-				api.itemsApi.getItems(
-					query.copy(
-						startIndex = startIndex,
-						limit = batchSize,
-					)
-				).content
+			val request = when {
+				batchSize > 0 -> query.copy(
+					startIndex = startIndex,
+					limit = batchSize,
+				)
+				startIndex > 0 -> query.copy(startIndex = startIndex)
+				else -> query
 			}
+
+			val response = withContext(Dispatchers.IO) {
+				api.itemsApi.getItems(request).content
+			}
+
+			setInitialSelectionIndex(
+				findInitialSelectionIndexByItemId(
+					items = response.items,
+					selectedItemId = initialSelectionItemId,
+				)
+			)
 
 			totalItems = response.totalRecordCount
 			setItems(

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/CustomPlaybackOverlayFragment.java
@@ -1364,8 +1364,7 @@ public class CustomPlaybackOverlayFragment extends Fragment implements LiveTvGui
         BaseItemDto currentEpisode = playbackControllerContainer.getValue().getPlaybackController().getCurrentlyPlayingItem();
         if (currentEpisode == null || currentEpisode.getSeasonId() == null) return;
         GetItemsRequest episodesRequest = org.jellyfin.androidtv.ui.browsing.BrowsingUtils.createNextEpisodesRequest(
-            currentEpisode.getSeasonId(),
-            0
+            currentEpisode.getSeasonId()
         );
 
         ItemRowAdapter episodeAdapter = new ItemRowAdapter(requireContext(), episodesRequest, 100, false, new CardPresenter(true, 110), new MutableObjectAdapter<Row>());

--- a/app/src/main/java/org/jellyfin/androidtv/ui/presentation/CustomListRowPresenter.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/presentation/CustomListRowPresenter.kt
@@ -3,9 +3,12 @@ package org.jellyfin.androidtv.ui.presentation
 import android.view.View
 import android.view.ViewGroup
 import androidx.core.view.isVisible
+import androidx.leanback.widget.BaseGridView
 import androidx.leanback.widget.ListRow
 import androidx.leanback.widget.ListRowPresenter
 import androidx.leanback.widget.RowPresenter
+import org.jellyfin.androidtv.R
+import org.jellyfin.androidtv.ui.itemhandling.ItemRowAdapter
 
 open class CustomListRowPresenter @JvmOverloads constructor(
     private val topPadding: Int? = null,
@@ -22,11 +25,27 @@ open class CustomListRowPresenter @JvmOverloads constructor(
         // No action needed
     }
 
+    override fun onRowViewSelected(holder: RowPresenter.ViewHolder, selected: Boolean) {
+        super.onRowViewSelected(holder, selected)
+        if (!selected) return
+        val listRowHolder = holder as? ListRowPresenter.ViewHolder ?: return
+        val listRow = listRowHolder.row as? ListRow ?: return
+        applyPendingSelection(listRowHolder, listRow)
+    }
+
     // Main implementation that handles binding
     @Suppress("DEPRECATION")
     override fun onBindRowViewHolder(holder: RowPresenter.ViewHolder, item: Any) {
         super.onBindRowViewHolder(holder, item)
         updateView(holder, item)
+    }
+
+    override fun onUnbindRowViewHolder(holder: RowPresenter.ViewHolder) {
+        val listRowHolder = holder as? ListRowPresenter.ViewHolder
+        val listRow = listRowHolder?.row as? ListRow
+        val rowAdapter = listRow?.adapter as? ItemRowAdapter
+        rowAdapter?.setSelectionIndexListener(null)
+        super.onUnbindRowViewHolder(holder)
     }
 
     private fun updateView(holder: RowPresenter.ViewHolder, item: Any) {
@@ -42,5 +61,45 @@ open class CustomListRowPresenter @JvmOverloads constructor(
 
         // Hide header view when the item doesn't have one
         holder.headerViewHolder.view.isVisible = !(item is ListRow && item.headerItem == null)
+
+        if (item is ListRow && holder is ListRowPresenter.ViewHolder) {
+            val rowAdapter = item.adapter as? ItemRowAdapter
+            if (isEpisodesRow(holder, item)) {
+                configureCenteredAlignment(holder)
+                rowAdapter?.setSelectionIndexListener { selectedIndex ->
+                    applyPendingSelection(holder, item, selectedIndex)
+                }
+            } else {
+                rowAdapter?.setSelectionIndexListener(null)
+            }
+            applyPendingSelection(holder, item)
+        }
+    }
+
+    private fun applyPendingSelection(
+        holder: ListRowPresenter.ViewHolder,
+        row: ListRow,
+        overrideIndex: Int? = null,
+    ) {
+        if (!isEpisodesRow(holder, row)) return
+        val rowAdapter = row.adapter as? ItemRowAdapter
+        val selectedIndex = overrideIndex ?: rowAdapter?.peekInitialSelectionIndex() ?: -1
+        if (selectedIndex >= 0) {
+            holder.gridView?.selectedPosition = selectedIndex
+            rowAdapter?.markInitialSelectionApplied()
+        }
+    }
+
+    private fun isEpisodesRow(holder: ListRowPresenter.ViewHolder, row: ListRow): Boolean {
+        val episodesLabel = holder.view.context.getString(R.string.lbl_episodes)
+        val headerName = row.headerItem?.name ?: return false
+        return headerName == episodesLabel || headerName.endsWith(" $episodesLabel")
+    }
+
+    private fun configureCenteredAlignment(holder: ListRowPresenter.ViewHolder) {
+        holder.gridView?.setWindowAlignment(BaseGridView.WINDOW_ALIGN_NO_EDGE)
+        holder.gridView?.setWindowAlignmentOffsetPercent(50f)
+        holder.gridView?.setItemAlignmentOffset(0)
+        holder.gridView?.setItemAlignmentOffsetPercent(50f)
     }
 }

--- a/app/src/test/kotlin/ui/browsing/BrowsingUtilsNextEpisodesTests.kt
+++ b/app/src/test/kotlin/ui/browsing/BrowsingUtilsNextEpisodesTests.kt
@@ -1,0 +1,26 @@
+package org.jellyfin.androidtv.ui.browsing
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import org.jellyfin.sdk.model.api.BaseItemKind
+import java.util.UUID
+
+class BrowsingUtilsNextEpisodesTests : FunSpec({
+	test("creates next episode request for full season list") {
+		val seasonId = UUID.randomUUID()
+		val request = BrowsingUtils.createNextEpisodesRequest(seasonId = seasonId)
+
+		request.parentId shouldBe seasonId
+		request.startIndex shouldBe null
+		request.limit shouldBe null
+		request.includeItemTypes shouldBe setOf(BaseItemKind.EPISODE)
+	}
+
+	test("does not change series next up request behavior") {
+		val seriesId = UUID.randomUUID()
+		val request = BrowsingUtils.createSeriesGetNextUpRequest(seriesId)
+
+		request.seriesId shouldBe seriesId
+		request.parentId shouldBe null
+	}
+})

--- a/app/src/test/kotlin/ui/itemhandling/ItemRowAdapterSelectionStateTests.kt
+++ b/app/src/test/kotlin/ui/itemhandling/ItemRowAdapterSelectionStateTests.kt
@@ -1,0 +1,64 @@
+package org.jellyfin.androidtv.ui.itemhandling
+
+import android.content.Context
+import androidx.leanback.widget.Presenter
+import androidx.leanback.widget.Row
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.mockk
+import org.jellyfin.androidtv.ui.presentation.MutableObjectAdapter
+import org.jellyfin.sdk.model.api.request.GetItemsRequest
+
+class ItemRowAdapterSelectionStateTests : FunSpec({
+	fun createAdapter(): ItemRowAdapter {
+		val context = mockk<Context>(relaxed = true)
+		val presenter = mockk<Presenter>(relaxed = true)
+		val parent = mockk<MutableObjectAdapter<Row>>(relaxed = true)
+		return ItemRowAdapter(
+			context,
+			GetItemsRequest(),
+			0,
+			false,
+			presenter,
+			parent,
+		)
+	}
+
+	test("peek keeps index pending until applied") {
+		val adapter = createAdapter()
+
+		adapter.setInitialSelectionIndex(3)
+		adapter.peekInitialSelectionIndex() shouldBe 3
+
+		adapter.markInitialSelectionApplied()
+		adapter.peekInitialSelectionIndex() shouldBe -1
+	}
+
+	test("consume supports focus-entry fallback behavior") {
+		val adapter = createAdapter()
+
+		adapter.setInitialSelectionIndex(2)
+		adapter.consumeInitialSelectionIndex() shouldBe 2
+		adapter.peekInitialSelectionIndex() shouldBe -1
+	}
+
+	test("listener fires when valid index becomes available") {
+		val adapter = createAdapter()
+		var callbackIndex = -1
+
+		adapter.setSelectionIndexListener { callbackIndex = it }
+		adapter.setInitialSelectionIndex(5)
+
+		callbackIndex shouldBe 5
+	}
+
+	test("listener does not fire when index stays pending at -1") {
+		val adapter = createAdapter()
+		var callbackIndex = -1
+
+		adapter.setSelectionIndexListener { callbackIndex = it }
+		adapter.setInitialSelectionIndex(-1)
+
+		callbackIndex shouldBe -1
+	}
+})

--- a/app/src/test/kotlin/ui/itemhandling/NextEpisodeCarouselWindowTests.kt
+++ b/app/src/test/kotlin/ui/itemhandling/NextEpisodeCarouselWindowTests.kt
@@ -1,0 +1,39 @@
+package org.jellyfin.androidtv.ui.itemhandling
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import org.jellyfin.sdk.model.api.BaseItemDto
+import org.jellyfin.sdk.model.api.BaseItemKind
+import java.util.UUID
+
+class NextEpisodeSelectionIndexTests : FunSpec({
+	test("returns current episode index when item id exists in season list") {
+		val episode1 = episode()
+		val episode2 = episode()
+		val episode3 = episode()
+
+		findInitialSelectionIndexByItemId(
+			items = listOf(episode1, episode2, episode3),
+			selectedItemId = episode2.id,
+		) shouldBe 1
+	}
+
+	test("returns -1 when selected item id is not in season list") {
+		findInitialSelectionIndexByItemId(
+			items = listOf(episode(), episode()),
+			selectedItemId = UUID.randomUUID(),
+		) shouldBe -1
+	}
+
+	test("returns -1 when selected item id is null") {
+		findInitialSelectionIndexByItemId(
+			items = listOf(episode(), episode()),
+			selectedItemId = null,
+		) shouldBe -1
+	}
+})
+
+private fun episode() = BaseItemDto(
+	id = UUID.randomUUID(),
+	type = BaseItemKind.EPISODE,
+)

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ org.gradle.jvmargs=-Xmx2048m
 # - "unstable-snapshot" (SDK with unstable Jellyfin API)
 sdk.version=default
 
-jellyfin.version=1.0.0
+jellyfin.version=1.0.1
 
 # Android
 android.useAndroidX=true


### PR DESCRIPTION
## Summary
- Load full-season episodes on episode details and preselect the currently viewed episode.
- Preposition the Episodes carousel before focus entry and keep centered alignment to avoid snap.
- Keep behavior scoped to Episodes rows, including season-prefixed headers like `S2 Episodes`.

## Test plan
- [x] `./gradlew :app:testDebugUnitTest --tests "org.jellyfin.androidtv.ui.itemhandling.ItemRowAdapterSelectionStateTests" --tests "org.jellyfin.androidtv.ui.itemhandling.NextEpisodeSelectionIndexTests" --tests "org.jellyfin.androidtv.ui.browsing.BrowsingUtilsNextEpisodesTests"`
- [x] Manual TV/emulator check: open episode details and verify centered preposition + no snap on row entry.
- [x] Manual regression check: non-Episodes rows unchanged.

## Linked issues
- #18